### PR TITLE
Use ENTRYPOINT instead of CMD for starting containers

### DIFF
--- a/src/into/docker/container.clj
+++ b/src/into/docker/container.clj
@@ -79,7 +79,8 @@
               :params {:name  container-name
                        :body {:Image full-name
                               :User  user
-                              :Entrypoint ["tail" "-f" "/dev/null"]
+                              :Entrypoint nil
+                              :Cmd ["tail" "-f" "/dev/null"]
                               :HostConfig
                               {:Mounts (vec
                                          (for [[path volume] volumes]

--- a/src/into/docker/container.clj
+++ b/src/into/docker/container.clj
@@ -79,7 +79,7 @@
               :params {:name  container-name
                        :body {:Image full-name
                               :User  user
-                              :Cmd   ["tail" "-f" "/dev/null"]
+                              :Entrypoint ["tail" "-f" "/dev/null"]
                               :HostConfig
                               {:Mounts (vec
                                          (for [[path volume] volumes]


### PR DESCRIPTION
I'm working on my 2nd into-docker builder for sqitch [1] and noticed
that into-docker fails to build because the runner image dies. I
believe this is because the runner image I'm using has defined an
ENTRYPOINT and a CMD [2]. So, when the into-docker starts the builder
and the runner image by executing `tail -f /dev/null` I think on the
the runner image the command that gets executed is `/bin/sqitch tail
-f /dev/null`, which fails and the runner container exists.

I got it working by using the `:Entrypoint` instruction in
`invoke-run-container` instead of `:Cmd`.

Wdyt?

[1] https://sqitch.org/
[2] https://github.com/sqitchers/docker-sqitch/blob/main/Dockerfile#L67