### PR TITLE
Fix handling of trailing slash in ignore pattern

### DIFF
--- a/src/into/utils/pattern.clj
+++ b/src/into/utils/pattern.clj
@@ -157,7 +157,8 @@
   (-> pattern
       (string/replace #"^(\./|/)+" "")
       (string/replace #"/\./" "/")
-      (string/replace #"/+" "/")))
+      (string/replace #"/+" "/")
+      (string/replace #"/$" "")))
 
 (defn- append-pattern
   [^StringBuilder sb pattern']

--- a/test/into/build/collect_sources_test.clj
+++ b/test/into/build/collect_sources_test.clj
@@ -11,6 +11,16 @@
         (is (nil? error))
         (is (= (set sources) (set source-paths)))))))
 
+(deftest t-collect-sources-with-ignore-paths
+  (let [sources ["a/x" "a/y" "c"]]
+    (with-temp-dir [dir sources]
+      (let [{:keys [source-paths error]}
+            (collect-sources/run
+              {:spec {:source-path (.getPath dir)}
+               :ignore-paths ["a/"]})]
+        (is (nil? error))
+        (is (= #{"c"} (set source-paths)))))))
+
 (deftest t-collect-sources-fails-if-no-files
   (with-temp-dir [dir []]
     (let [{:keys [source-paths ^Exception error]}
@@ -18,7 +28,6 @@
       (is (empty? source-paths))
       (is (re-matches #"^No source files found in.*"
                       (.getMessage error))))))
-
 
 (deftest t-collect-sources-fails-if-everything-is-ignored
   (with-temp-dir [dir ["a" "aa" "aaa"]]

--- a/test/into/utils/pattern_test.clj
+++ b/test/into/utils/pattern_test.clj
@@ -41,6 +41,11 @@
     (let [matcher (pattern/matcher [pattern])]
       (matcher path))))
 
+(defspec t-matcher-should-normalize-end-of-pattern (times 20)
+  (prop/for-all [path (s/gen ::spec/path)]
+    (let [matcher (pattern/matcher [(str path "/")])]
+      (matcher path))))
+
 (defspec t-matcher-should-normalize-pattern (times 20)
   (prop/for-all [path (s/gen ::spec/path)]
     (let [pattern (string/replace path "/" "/./")


### PR DESCRIPTION
While trying out the create-react-app builder, I discovered that `node_modules` are transferred into the builder (which takes a long time). This is a regression, caused by the trailing slash in the `node_modules/` line in the builder's `ignore` file.