### PR TITLE
Add caching via volume (experimental)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: DeLaGuardo/clojure-lint-action@v1
+      - uses: DeLaGuardo/clojure-lint-action@master
         with:
           clj-kondo-args: --lint src test
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/WHITEPAPER.md
+++ b/doc/WHITEPAPER.md
@@ -386,6 +386,18 @@ node_modules
 /into/home/.npm
 ```
 
+#### Cache Volumes
+
+**Experimental: This is a preliminary assessment of a feature and might be re-
+evaluated and change.**
+
+As an alternative to archiving/extracting the cache path, a build coordinator
+could use a Docker volume as the source/target for caching. This would limit the
+interactions with the cache to moving files.
+
+There should be a significant speed-up when this approach is available,
+for example, when running builds on non-CI machines, e.g. locally.
+
 ### Source Exclusions
 
 A file located at `/into/ignore` will be used as the basis for

--- a/src/into/build.clj
+++ b/src/into/build.clj
@@ -28,17 +28,27 @@
    [nil, "--no-volumes" "Do not use shared volumes."
     :id :no-volumes?
     :default false]
-   [nil "--cache path" "Use and create the specified cache file for incremental builds."
+   ["-i" "--incremental" "Run an incremental build utilising a Docker volume for caching."
+    :id :incremental?
+    :default false]
+   [nil "--cache path" "Run an incremental build utilising the given cache file."
     :id :cache-file]])
 
 ;; ## Spec
 
 (defn- build-spec
-  [{:keys [target-image artifact-path profile cache-file ci-type no-volumes?]}
+  [{:keys [target-image
+           artifact-path
+           profile
+           cache-file
+           ci-type
+           incremental?
+           no-volumes?]}
    [builder-image source-path]]
   (cond-> {:builder-image-name builder-image
-           :source-path   (or source-path ".")
-           :use-volumes?  (not no-volumes?)}
+           :source-path        (or source-path ".")
+           :use-cache-volume?  (and incremental? (not cache-file))
+           :use-volumes?       (not no-volumes?)}
     target-image  (assoc :target-image-name target-image)
     artifact-path (assoc :artifact-path artifact-path)
     profile       (assoc :profile profile)

--- a/src/into/build/add_cache_volume.clj
+++ b/src/into/build/add_cache_volume.clj
@@ -1,0 +1,33 @@
+(ns into.build.add-cache-volume
+  (:require [into.constants :as constants]
+            [into.log :as log]
+            [into.utils.sha1 :refer [sha1]]
+            [clojure.java.io :as io]))
+
+(defn- cache-volume-name
+  [{{:keys [source-path]} :spec
+    {:keys [full-name]} :builder-image}]
+  (let [abs-path (.getAbsolutePath (io/file source-path))]
+    (->> (str full-name "~" abs-path)
+         (sha1)
+         (str "into-docker-cache-"))))
+
+(defn- add-cache-volume
+  [data]
+  (let [volume-name (cache-volume-name data)]
+    (log/debug "Using cache volume: %s" volume-name)
+    (->> {:name    volume-name
+          :path    (constants/path-for :cache-directory)
+          :retain? true}
+         (update-in data [:builder-image :volumes] conj))))
+
+(defn- use-cache-volume?
+  [{:keys [spec]}]
+  (and (:use-cache-volume? spec)
+       (:use-volumes? spec)))
+
+(defn run
+  [data]
+  (if (use-cache-volume? data)
+    (add-cache-volume data)
+    data))

--- a/src/into/build/add_shared_volume.clj
+++ b/src/into/build/add_shared_volume.clj
@@ -8,11 +8,10 @@
 
 (defn- add-shared-volume
   [data image-key volume-name]
-  (assoc-in data
-            [image-key
-             :volumes
-             (constants/path-for :artifact-directory)]
-            volume-name))
+  (->> {:name     volume-name
+        :path     (constants/path-for :artifact-directory)
+        :retain?  false}
+       (update-in data [image-key :volumes] conj)))
 
 (defn- use-shared-volume?
   [{:keys [spec]}]

--- a/src/into/build/flow.clj
+++ b/src/into/build/flow.clj
@@ -2,6 +2,7 @@
   (:require [into.flow :as flow]
             [into.build
              [add-builder-env :as add-builder-env]
+             [add-cache-volume :as add-cache-volume]
              [add-default-labels :as add-default-labels]
              [add-oci-labels :as add-oci-labels]
              [add-runner-env :as add-runner-env]
@@ -11,11 +12,13 @@
              [cleanup :as cleanup]
              [collect-sources :as collect-sources]
              [commit :as commit]
-             [create-cache :as create-cache]
              [create-working-directories :as create-working-directories]
+             [export-cache-file :as export-cache-file]
              [finalise :as finalise]
              [initialise :as initialise]
+             [inject-cache-file :as inject-cache-file]
              [inject-sources :as inject-sources]
+             [prepare-cache :as prepare-cache]
              [prepare-target-image :as prepare-target-image]
              [pull :as pull]
              [read-buildenv :as read-buildenv]
@@ -44,6 +47,7 @@
         (add-default-labels/run)
         (add-oci-labels/run)
         (add-shared-volume/run)
+        (add-cache-volume/run)
         (start/run)
 
         ;; --- Prepare the builder and runner
@@ -54,6 +58,7 @@
         (add-runner-env/run)
         (create-working-directories/run)
         (transfer-assemble-script/run)
+        (inject-cache-file/run)
         (restore-cache/run)
 
         ;; --- Run build script
@@ -68,6 +73,7 @@
         (commit/run)
 
         ;; --- Finalise
-        (create-cache/run))
+        (prepare-cache/run)
+        (export-cache-file/run))
       (cleanup/run)
       (finalise/run)))

--- a/src/into/build/inject_cache_file.clj
+++ b/src/into/build/inject_cache_file.clj
@@ -1,0 +1,33 @@
+(ns into.build.inject-cache-file
+  (:require [into
+             [constants :as constants]
+             [docker :as docker]
+             [log :as log]]
+            [into.utils.cache :as cache]
+            [clojure.java.io :as io]))
+
+;; ## Cache File Injection
+
+(defn- inject-cache-file!
+  [{:keys [spec builder-container]}]
+  (let [cache-from (:cache-from spec)]
+    (log/debug "Injecting contents of cache archive: %s" cache-from)
+    (with-open [in (io/input-stream cache-from)]
+      (docker/stream-into-container
+        builder-container
+        (constants/path-for :working-directory)
+        in))))
+
+;; ## Flow
+
+(defn- inject-cache-file?
+  [{:keys [spec builder-container cache-paths]}]
+  (and (seq cache-paths)
+       builder-container
+       (cache/cache-file-exists? spec)))
+
+(defn run
+  [data]
+  (when (inject-cache-file? data)
+    (inject-cache-file! data))
+  data)

--- a/src/into/build/prepare_cache.clj
+++ b/src/into/build/prepare_cache.clj
@@ -1,0 +1,31 @@
+(ns into.build.prepare-cache
+  (:require [into
+             [constants :as constants]
+             [docker :as docker]
+             [log :as log]]
+            [into.utils.cache :as cache]))
+
+;; ## Create Cache
+
+(defn- prepare-cache-files!
+  "Copy all cache paths to `path` to prepare for extraction."
+  [{:keys [builder-container cache-paths]}]
+  (let [path (constants/path-for :cache-directory)
+        cmd  (cache/prepare-cache-command path cache-paths)]
+    (log/debug "Preparing cache paths: %s" cache-paths)
+    (docker/exec-and-log builder-container {:cmd cmd})))
+
+;; ## Flow
+
+(defn- prepare-cache-files?
+  [{:keys [spec builder-container cache-paths]}]
+  (and (seq cache-paths)
+       builder-container
+       (or (cache/cache-file-used? spec)
+           (cache/cache-volume-used? spec))))
+
+(defn run
+  [data]
+  (when (prepare-cache-files? data)
+    (prepare-cache-files! data))
+  data)

--- a/src/into/build/restore_cache.clj
+++ b/src/into/build/restore_cache.clj
@@ -3,42 +3,28 @@
              [constants :as constants]
              [docker :as docker]
              [log :as log]]
-            [into.utils.cache :as cache]
-            [clojure.java.io :as io]))
+            [into.utils.cache :as cache]))
 
-;; ## Cache File Injection
-
-(defn- inject-cache-directory!
-  [builder-container cache-from]
-  (with-open [in (io/input-stream cache-from)]
-    (docker/stream-into-container
-     builder-container
-     (constants/path-for :working-directory)
-     in)))
+;; ## Move Cache Files to original locations
 
 (defn- restore-cache-files!
-  [builder-container cache-paths]
+  [{:keys [builder-container cache-paths]}]
+  (log/debug "Restoring cache paths: %s" cache-paths)
   (let [cmd (cache/restore-cache-command
-             (constants/path-for :cache-directory)
-             cache-paths)]
+              (constants/path-for :cache-directory)
+              cache-paths)]
     (docker/exec-and-log builder-container {:cmd cmd})))
-
-(defn- restore-cache!
-  [{:keys [spec builder-container cache-paths]}]
-  (let [cache-from (:cache-from spec)]
-    (log/info "Restoring cache from '%s' ..." cache-from)
-    (inject-cache-directory! builder-container cache-from)
-    (restore-cache-files! builder-container cache-paths)))
 
 ;; ## Flow
 
-(defn- restore-cache?
+(defn restore-cache?
   [{:keys [spec cache-paths]}]
-  (and (some-> spec :cache-from io/file (.isFile))
-       (seq cache-paths)))
+  (and (seq cache-paths)
+       (or (cache/cache-file-exists? spec)
+           (cache/cache-volume-used? spec))))
 
 (defn run
   [data]
   (when (restore-cache? data)
-    (restore-cache! data))
+    (restore-cache-files! data))
   data)

--- a/src/into/build/spec.clj
+++ b/src/into/build/spec.clj
@@ -55,6 +55,7 @@
   (s/keys :req-un [::source-path
                    ::builder-image-name
                    ::profile
+                   ::use-cache-volume?
                    ::use-volumes?]
           :opt-un [::artifact-path
                    ::cache-from
@@ -69,6 +70,7 @@
 (s/def ::profile ::name)
 (s/def ::ci-type #{"github-actions", "local"})
 (s/def ::use-volumes? boolean?)
+(s/def ::use-cache-volume? boolean?)
 
 ;; ## Image
 
@@ -81,13 +83,22 @@
                    ::cmd
                    ::entrypoint]))
 
+(s/def ::image-with-volumes
+  (s/merge ::image (s/keys :opt-un [::volumes])))
+
 (s/def ::tag        ::non-empty-string)
 (s/def ::user       ::non-empty-string)
 (s/def ::labels     (s/map-of (s/or :k keyword? :s string?) string?))
 (s/def ::cmd        (s/coll-of string?))
 (s/def ::entrypoint (s/coll-of string?))
+(s/def ::volumes    (s/coll-of ::volume))
+(s/def ::volume
+  (s/keys :req-un [::name
+                   ::path
+                   ::retain?]))
+(s/def ::retain? boolean?)
 
-(s/def ::builder-image ::image)
+(s/def ::builder-image ::image-with-volumes)
 (s/def ::runner-image  ::image)
 (s/def ::target-image  ::image)
 

--- a/src/into/utils/cache.clj
+++ b/src/into/utils/cache.clj
@@ -5,18 +5,8 @@
    - Export TAR from the container.
    Reverse to restore."
   (:require [clojure.string :as string]
-            [clojure.java.io :as io])
-  (:import [java.security MessageDigest]))
-
-(defn- sha1
-  "We need to create a fingerprint for cache paths that we can use
-   inside a TAR file as directory name."
-  [^String s]
-  (let [instance (MessageDigest/getInstance "SHA1")
-        ^bytes data (.getBytes s "UTF-8")]
-    (->> (.digest instance data)
-         (map #(format "%02x" %))
-         (apply str))))
+            [clojure.java.io :as io]
+            [into.utils.sha1 :refer [sha1]]))
 
 (defn- ->prepare-command
   [cache-directory path]
@@ -66,3 +56,19 @@
        (string/join "; ")
        (format "%s; true")
        (vector "sh" "-c")))
+
+;; ## Utility
+
+(defn cache-file-exists?
+  [spec]
+  (some-> spec :cache-from io/file (.isFile)))
+
+
+(defn cache-file-used?
+  [spec]
+  (some? (:cache-to spec)))
+
+(defn cache-volume-used?
+  [spec]
+  (and (:use-cache-volume? spec)
+       (:use-volumes? spec)))

--- a/src/into/utils/sha1.clj
+++ b/src/into/utils/sha1.clj
@@ -1,0 +1,11 @@
+(ns into.utils.sha1
+  (:import [java.security MessageDigest]))
+
+(defn sha1
+  "Create SHA-1 hash from string."
+  [^String s]
+  (let [instance (MessageDigest/getInstance "SHA1")
+        ^bytes data (.getBytes s "UTF-8")]
+    (->> (.digest instance data)
+         (map #(format "%02x" %))
+         (apply str))))

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -9,7 +9,7 @@ BUILDER_IMAGE="into-docker-e2e-test:$TAG"
 TARGET_IMAGE="into-docker-e2e-target:$TAG"
 
 build_and_check() {
-    $BUILD -vv \
+    $BUILD -v \
         "$@" \
         -t "$TARGET_IMAGE" \
         "$BUILDER_IMAGE" "$WORKDIR"
@@ -20,7 +20,7 @@ build_and_check() {
 build_artifacts_and_check() {
     ARTIFACT_DIR="$WORKDIR/../../target/artifacts"
     mkdir -p "$ARTIFACT_DIR"
-    $BUILD -vv \
+    $BUILD -v \
         --write-artifacts "$ARTIFACT_DIR" \
         "$BUILDER_IMAGE" \
         "$WORKDIR"

--- a/test/into/build/add_cache_volume_test.clj
+++ b/test/into/build/add_cache_volume_test.clj
@@ -1,0 +1,39 @@
+(ns into.build.add-cache-volume-test
+  (:require [clojure.test.check
+             [clojure-test :refer [defspec]]
+             [generators :as gen]
+             [properties :as prop]]
+            [com.gfredericks.test.chuck :refer [times]]
+            [clojure.spec.alpha :as s]
+            [into.build.spec :as spec]
+            [into.build.add-cache-volume :as add-cache-volume]))
+
+;; ## Helpers
+
+(def ^:private volume-path
+  "/tmp/cache")
+
+(defn- cache-volume-of
+  [{:keys [volumes]}]
+  (first (filter #(= (:path %) volume-path) volumes)))
+
+;; ## Tests
+
+(defspec t-add-cache-volume (times 20)
+  (prop/for-all
+    [spec (gen/let [spec (s/gen ::spec/spec)]
+            (assoc spec
+                   :use-volumes? true
+                   :use-cache-volume? true))]
+    (let [{:keys [builder-image]} (add-cache-volume/run {:spec spec})
+          builder-volume (cache-volume-of builder-image)]
+      (:retain? builder-volume))))
+
+(defspec t-add-cache-volume-does-nothing-if-disabled (times 20)
+  (prop/for-all
+    [spec (gen/let [spec (s/gen ::spec/spec)]
+            (gen/elements
+              [(assoc spec :use-volumes? false)
+               (assoc spec :use-cache-volume? false)]))]
+    (let [{:keys [builder-image]} (add-cache-volume/run {:spec spec})]
+      (not (cache-volume-of builder-image)))))

--- a/test/into/build/add_shared_volume_test.clj
+++ b/test/into/build/add_shared_volume_test.clj
@@ -8,11 +8,24 @@
             [into.build.spec :as spec]
             [into.build.add-shared-volume :as add-shared-volume]))
 
+;; ## Helpers
+
+(def ^:private volume-path
+  "/tmp/artifacts")
+
+(defn- shared-volume-of
+  [{:keys [volumes]}]
+  (first (filter #(= (:path %) volume-path) volumes)))
+
+;; ## Tests
+
 (defspec t-add-shared-volume (times 20)
   (prop/for-all
     [spec          (gen/let [n    (s/gen ::spec/target-image-name)
                              spec (s/gen ::spec/spec)]
-                     (assoc spec :use-volumes? true, :target-image-name n))
+                     (assoc spec
+                            :use-volumes? true
+                            :target-image-name n))
      builder-image (s/gen ::spec/builder-image)
      runner-image  (s/gen ::spec/runner-image)]
     (let [{:keys [builder-image runner-image]}
@@ -20,11 +33,12 @@
             {:spec          spec
              :builder-image builder-image
              :runner-image  runner-image})
-          builder-volumes (:volumes builder-image)
-          runner-volumes (:volumes runner-image)]
-      (and (contains? builder-volumes "/tmp/artifacts")
-           (contains? runner-volumes "/tmp/artifacts")
-           (= builder-volumes runner-volumes)))))
+          builder-volume (shared-volume-of builder-image)
+          runner-volume (shared-volume-of runner-image)]
+      (and builder-volume
+           runner-volume
+           (not (:retain? builder-volume))
+           (= builder-volume runner-volume)))))
 
 (defspec t-add-shared-volume-does-nothing-when-disabled-or-without-target-image (times 20)
   (prop/for-all
@@ -39,8 +53,6 @@
             {:spec          spec
              :builder-image builder-image
              :runner-image  runner-image})
-          builder-volumes (:volumes builder-image)
-          runner-volumes (:volumes runner-image)]
-      (not
-        (or (contains? builder-volumes "/tmp/artifacts")
-            (contains? runner-volumes "/tmp/artifacts"))))))
+          builder-volume (shared-volume-of builder-image)
+          runner-volume (shared-volume-of runner-image)]
+      (not (or builder-volume runner-volume)))))

--- a/test/into/build/export_cache_file_test.clj
+++ b/test/into/build/export_cache_file_test.clj
@@ -1,10 +1,10 @@
-(ns into.build.create-cache-test
+(ns into.build.export-cache-file-test
   (:require [clojure.test :refer [deftest is]]
             [clojure.tools.logging.test :refer [with-log]]
             [clojure.java.io :as io]
             [into.docker :as docker]
             [into.docker.mock :as mock]
-            [into.build.create-cache :as create-cache]
+            [into.build.export-cache-file :as export-cache-file]
             [into.test.files :refer [with-temp-dir]])
   (:import (java.util.zip GZIPInputStream)))
 
@@ -20,7 +20,7 @@
 
 ;; ## Tests
 
-(deftest t-create-cache
+(deftest t-export-cache-file
   (with-log
     (with-temp-dir [tmp []]
       (let [content  "TEST"
@@ -29,13 +29,13 @@
             data     {:spec              {:cache-to cache-to}
                       :builder-container builder
                       :cache-paths       ["/some/file"]}
-            data'    (create-cache/run data)]
+            data'    (export-cache-file/run data)]
         (is (= data' data))
         (with-open [in (io/input-stream cache-to)
                     gz (GZIPInputStream. in)]
           (is (= content (slurp gz))))))))
 
-(deftest t-create-cache-does-nothing-without-cache-paths
+(deftest t-export-cache-file-does-nothing-without-cache-paths
   (with-log
     (with-temp-dir [tmp []]
       (let [content  "TEST"
@@ -44,30 +44,16 @@
             data     {:spec              {:cache-to cache-to}
                       :builder-container builder
                       :cache-paths       []}
-            data'    (create-cache/run data)]
+            data'    (export-cache-file/run data)]
         (is (= data' data))
         (is (not (.isFile cache-to)))))))
 
-(deftest t-create-cache-failure
-  (with-log
-    (with-temp-dir [tmp []]
-      (let [content  "TEST"
-            cache-to (io/file tmp "cache.gz")
-            builder  (cache-source-container 1 content)
-            data     {:spec              {:cache-to cache-to}
-                      :builder-container builder
-                      :cache-paths       ["/some/file"]}]
-        (is (thrown-with-msg?
-              IllegalStateException
-              #"Exec in container (.+) failed!"
-              (create-cache/run data)))))))
-
-(deftest t-create-cache-does-nothing-without-cache-to
+(deftest t-export-cache-file-does-nothing-without-cache-to
   (with-log
     (let [content  "TEST"
           builder  (cache-source-container 1 content)
           data     {:spec              {}
                     :builder-container builder
                     :cache-paths       ["/some/file"]}
-          data'    (create-cache/run data)]
+          data'    (export-cache-file/run data)]
       (is (= data' data)))))

--- a/test/into/build/prepare_cache_test.clj
+++ b/test/into/build/prepare_cache_test.clj
@@ -1,0 +1,72 @@
+(ns into.build.prepare-cache-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.tools.logging.test :refer [with-log]]
+            [clojure.java.io :as io]
+            [into.docker :as docker]
+            [into.docker.mock :as mock]
+            [into.build.prepare-cache :as prepare-cache]
+            [into.test.files :refer [with-temp-dir]]))
+
+;; ## Helpers
+
+(defn- cache-source-container
+  [exit-code]
+  (reify docker/DockerContainer
+    (run-container-command [this _]
+      (mock/->MockExec this []  {:exit exit-code}))))
+
+;; ## Tests
+
+(deftest t-prepare-cache
+  (with-log
+    (with-temp-dir [tmp []]
+      (let [cache-to (io/file tmp "cache.gz")
+            builder  (cache-source-container 0)
+            data     {:spec              {:cache-to cache-to}
+                      :builder-container builder
+                      :cache-paths       ["/some/file"]}
+            data'    (prepare-cache/run data)]
+        (is (= data' data))))))
+
+(deftest t-prepare-cache-with-cache-volume
+  (with-log
+    (let [builder  (cache-source-container 0)
+          data     {:spec              {:use-cache-volume? true
+                                        :use-volumes? true}
+                    :builder-container builder
+                    :cache-paths       ["/some/file"]}
+          data'    (prepare-cache/run data)]
+      (is (= data' data)))))
+
+(deftest t-prepare-cache-does-nothing-without-cache-paths
+  (with-log
+    (with-temp-dir [tmp []]
+      (let [cache-to (io/file tmp "cache.gz")
+            builder  (cache-source-container 0)
+            data     {:spec              {:cache-to cache-to}
+                      :builder-container builder
+                      :cache-paths       []}
+            data'    (prepare-cache/run data)]
+        (is (= data' data))))))
+
+(deftest t-prepare-cache-failure
+  (with-log
+    (with-temp-dir [tmp []]
+      (let [cache-to (io/file tmp "cache.gz")
+            builder  (cache-source-container 1)
+            data     {:spec              {:cache-to cache-to}
+                      :builder-container builder
+                      :cache-paths       ["/some/file"]}]
+        (is (thrown-with-msg?
+              IllegalStateException
+              #"Exec in container (.+) failed!"
+              (prepare-cache/run data)))))))
+
+(deftest t-prepare-cache-does-nothing-without-cache-to-or-volume
+  (with-log
+    (let [builder  (cache-source-container 1)
+          data     {:spec              {}
+                    :builder-container builder
+                    :cache-paths       ["/some/file"]}
+          data'    (prepare-cache/run data)]
+      (is (= data' data)))))

--- a/test/into/build_test.clj
+++ b/test/into/build_test.clj
@@ -21,6 +21,7 @@
            :target-image-name  "test:latest"
            :source-path        "."
            :use-volumes?       true
+           :use-cache-volume?  false
            :ci-type            nil
            :cache-from         nil
            :cache-to           nil
@@ -28,6 +29,7 @@
   (testing "CLI args"
     (let [data (capture-spec "-t" "test:latest"
                              "-p" "profile-x"
+                             "--incremental"
                              "--write-artifacts" "artifacts"
                              "--ci" "github-actions"
                              "--cache" "cache"
@@ -39,10 +41,23 @@
            :target-image-name  "test:latest"
            :source-path        "./path"
            :use-volumes?       false
+           :use-cache-volume?  false
            :ci-type            "github-actions"
            :cache-from         "cache"
            :cache-to           "cache"
            :profile            "profile-x")))
+  (testing "CLI arg: '--incremental'"
+    (let [data (capture-spec "--incremental" "-t" "test:latest" "builder")]
+      (are [k v] (= v (get-in data [:spec k]))
+           :builder-image-name "builder"
+           :target-image-name  "test:latest"
+           :source-path        "."
+           :use-volumes?       true
+           :use-cache-volume?  true
+           :ci-type            nil
+           :cache-from         nil
+           :cache-to           nil
+           :profile            "default")))
   (testing "validation"
     (with-log
       (capture-spec "-t" "" "builder")

--- a/test/into/docker/container_test.clj
+++ b/test/into/docker/container_test.clj
@@ -33,7 +33,10 @@
   (fn [f]
     (binding [client (client/start base-client)]
       (let [image  (-> (docker/pull-image-record client container-image)
-                       (assoc :volumes {"/tmp/volume-ext" (str container-name "-vol")}))]
+                       (assoc :volumes
+                              [{:path "/tmp/volume-ext"
+                                :name (str container-name "-vol")
+                                :retain? false}]))]
         (binding [container (docker/container client container-name image)]
           (docker/run-container container)
           (try
@@ -104,11 +107,7 @@
                container
                {:cmd ["sh" "-c" "echo $STRING_TO_ECHO; exit 0"]
                 :env ["STRING_TO_ECHO=1234"]})]
-    (is (zero? (:exit result)))
-    #_(is (thrown-with-msg?
-          IllegalStateException
-          #"Exec in container \(busybox\) failed!"
-          (docker/wait-for-exec exec)))))
+    (is (zero? (:exit result)))))
 
 (deftest ^:docker t-exec-and-wait-failure
   (is (thrown-with-msg?


### PR DESCRIPTION
This adjusts into-docker's behaviour to support usage of cache volumes. This should make local builds quicker since archives won't be streamed from into or out of containers.