### PR TITLE
Add ability to select platform to docker client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository

--- a/README.md
+++ b/README.md
@@ -158,6 +158,21 @@ fill image labels.
 
 Check out the `into.build.ci` namespace if you want to add more environments.
 
+### Platforms
+
+If you're [targeting multiple platforms][docker-arch] or platforms different
+from your build machine, you can use the `--platform` CLI options:
+
+```sh
+into build -t <name:tag> --platform linux/arm64 [--force-platform] <builder>
+```
+
+By default, this will only impact the target image - the build itself will be
+run on your host's platform. If you want to use the same platform across all
+build steps (which can be necessary to ensure binary compatibility), just add
+the `--force-platform` flag. (Check out the [documentation][platforms] for the
+rationale.)
+
 [di]: https://codefresh.io/docker-tutorial/not-ignore-dockerignore-2/
 [oci]: https://github.com/opencontainers/image-spec/blob/master/annotations.md
 [s2i]: https://github.com/openshift/source-to-image
@@ -166,6 +181,8 @@ Check out the `into.build.ci` namespace if you want to add more environments.
 [build-profiles]: doc/WHITEPAPER.md#build-profiles
 [builder-caching]: doc/WHITEPAPER.md#caching
 [buildenv]: doc/WHITEPAPER.md#user-provided-environment-variables
+[platforms]: doc/WHITEPAPER.md#platforms
+[docker-arch]: https://docs.docker.com/desktop/multi-arch/
 
 ## License
 

--- a/doc/WHITEPAPER.md
+++ b/doc/WHITEPAPER.md
@@ -494,6 +494,17 @@ BUILD_COMMAND=npm run build
 Note how both `INSTALL_COMMAND` and `BUILD_COMMAND` have to be repeated in the
 second profile since there is no notion of inheritance or overriding.
 
+### Platforms
+
+Sometimes it's beneficial to specify the platform of the created image, e.g.
+when build and deployment machines differ. However, such builds can be slow, and
+thus any optimisation will be appreciated.
+
+Specifically, if the build provides artifacts that can run on any platform
+(e.g. Java JARs, or plain sources for NodeJS), only the runner container must
+adhere to the desired platform, meaning the builder container will not be
+impacted by any performance hits.
+
 ## Outlook
 
 ### Builder Image Inspection

--- a/src/into/build.clj
+++ b/src/into/build.clj
@@ -32,7 +32,11 @@
     :id :incremental?
     :default false]
    [nil "--cache path" "Run an incremental build utilising the given cache file."
-    :id :cache-file]])
+    :id :cache-file]
+   [nil, "--platform platform" "Set platform for runner container and resulting image."
+    :id :platform]
+   [nil "--force-platform" "Use platform for all containers to ensure compatibility."
+    :id :force-platform?]])
 
 ;; ## Spec
 
@@ -43,6 +47,8 @@
            cache-file
            ci-type
            incremental?
+           platform
+           force-platform?
            no-volumes?]}
    [builder-image source-path]]
   (cond-> {:builder-image-name builder-image
@@ -53,6 +59,9 @@
     artifact-path (assoc :artifact-path artifact-path)
     profile       (assoc :profile profile)
     ci-type       (assoc :ci-type ci-type)
+    platform      (cond->
+                   force-platform? (assoc :builder-platform platform)
+                   :always         (assoc :runner-platform platform))
     cache-file    (merge {:cache-from cache-file, :cache-to cache-file})))
 
 ;; ## Run

--- a/src/into/build/pull.clj
+++ b/src/into/build/pull.clj
@@ -10,6 +10,8 @@
 (defn- pull-image!
   [{:keys [client] :as data} target-key platform image-name]
   (log/debug "  Pulling image [%s] ..." image-name)
+  (when-let [p (or platform (:platform client))]
+    (log/debug "    Platform: %s" p))
   (if-let [image (-> client
                      (cond-> platform (docker/with-platform platform))
                      (docker/pull-image-record image-name))]

--- a/src/into/build/pull.clj
+++ b/src/into/build/pull.clj
@@ -8,25 +8,28 @@
 ;; ## Steps
 
 (defn- pull-image!
-  [{:keys [client] :as data} target-key image-name]
+  [{:keys [client] :as data} target-key platform image-name]
   (log/debug "  Pulling image [%s] ..." image-name)
-  (if-let [image (docker/pull-image-record client image-name)]
+  (if-let [image (-> client
+                     (cond-> platform (docker/with-platform platform))
+                     (docker/pull-image-record image-name))]
     (assoc data target-key image)
     (flow/fail data (str "Image not found: " image-name))))
 
 (defn- pull-builder-image!
-  [data]
-  (->> (get-in data [:spec :builder-image-name])
-       (pull-image! data :builder-image)))
+  [{:keys [spec] :as data}]
+  (let [{:keys [builder-image-name builder-platform]} spec]
+    (pull-image! data :builder-image builder-platform builder-image-name)))
 
 (defn- pull-runner-image!
-  [data]
-  (if (get-in data [:spec :target-image-name])
-    (->> (get-in data [:builder-image
-                       :labels
-                       constants/runner-image-label])
-         (pull-image! data :runner-image))
-    data))
+  [{:keys [spec] :as data}]
+  (let [{:keys [target-image-name runner-platform]} spec]
+    (if target-image-name
+      (->> (get-in data [:builder-image
+                         :labels
+                         constants/runner-image-label])
+           (pull-image! data :runner-image runner-platform))
+      data)))
 
 (defn- set-builder-user
   [data]

--- a/src/into/build/spec.clj
+++ b/src/into/build/spec.clj
@@ -61,6 +61,8 @@
                    ::cache-from
                    ::cache-to
                    ::ci-type
+                   ::builder-platform
+                   ::runner-platform
                    ::target-image-name]))
 
 (s/def ::source-path ::path)
@@ -68,6 +70,8 @@
 (s/def ::builder-image-name ::image-name)
 (s/def ::target-image-name ::image-name)
 (s/def ::profile ::name)
+(s/def ::builder-platform string?)
+(s/def ::runner-platform string?)
 (s/def ::ci-type #{"github-actions", "local"})
 (s/def ::use-volumes? boolean?)
 (s/def ::use-cache-volume? boolean?)

--- a/src/into/docker.clj
+++ b/src/into/docker.clj
@@ -143,6 +143,7 @@
 ;; ## Client Facade
 
 (defprotocol+ DockerClient
+  (with-platform [this platform])
   (pull-image [this image-name])
   (inspect-image [this image-name])
   (container

--- a/src/into/docker/client.clj
+++ b/src/into/docker/client.clj
@@ -66,6 +66,8 @@
 
 (defrecord DockerClient [platform uri conn clients]
   proto/DockerClient
+  (with-platform [this platform]
+    (assoc this :platform platform))
   (pull-image [this image]
     (invoke-pull-image this image))
   (inspect-image [this image]

--- a/src/into/docker/progress.clj
+++ b/src/into/docker/progress.clj
@@ -16,7 +16,7 @@
 
 (defn- print-layer-progress
   [id {:keys [status progress]}]
-  (println "[into]   " (str (char 27) "[K" (format "%s %-11s %s" id status progress))))
+  (println "[into]    " (str (char 27) "[K" (format "%s %-11s %s" id status progress))))
 
 (defn progress-printer
   "Create a stateful function that prints a progress report. It takes layer

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -9,6 +9,7 @@ BUILDER_IMAGE="into-docker-e2e-test:$TAG"
 TARGET_IMAGE="into-docker-e2e-target:$TAG"
 
 build_and_check() {
+    echo ">>>> $BUILD $@ <<<<"
     $BUILD -v \
         "$@" \
         -t "$TARGET_IMAGE" \
@@ -39,8 +40,10 @@ export SECRET_PASSWORD="password"
 build_and_check
 build_and_check --no-volumes
 
+# Build the image for another platform
+build_and_check --platform linux/arm64
+
 # Build the image using a cache
-set -x
 rm -f "$WORKDIR/cache.tar.gz"
 build_and_check --cache $WORKDIR/cache.tar.gz
 build_and_check --cache $WORKDIR/cache.tar.gz

--- a/test/into/docker/mock.clj
+++ b/test/into/docker/mock.clj
@@ -312,6 +312,8 @@
 
 (defrecord MockClient [containers images]
   docker/DockerClient
+  (with-platform [this _]
+    this)
   (pull-image [_ _])
   (inspect-image [_ image]
     (get images image))


### PR DESCRIPTION
This adds the general ability to select a platform via `$DOCKER_DEFAULT_PLATFORM` when building images. There are some thoughts to be had, still:
* If no platform is set, it will use the last available image, even if it has the _wrong_ platform.
* For some builds (e.g. JVM apps), only the runner needs to adhere to the platform (assuming it's possible to transfer data between containers running different platforms).