### PR TITLE
Remove '--force-platform'

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,14 +150,13 @@ If you're [targeting multiple platforms][docker-arch] or platforms different
 from your build machine, you can use the `--platform` CLI options:
 
 ```sh
-into build -t <name:tag> --platform linux/arm64 [--force-platform] <builder>
+into build -t <name:tag> --platform linux/arm64 <builder>
 ```
 
 By default, this will only impact the target image - the build itself will be
-run on your host's platform. If you want to use the same platform across all
-build steps (which can be necessary to ensure binary compatibility), just add
-the `--force-platform` flag. (Check out the [documentation][platforms] for the
-rationale.)
+run on your host's platform. You can use the environment variable
+`DOCKER_DEFAULT_PLATFORM` to adapt the builder container's platform. Check out
+the [WHITEPAPER][platforms] for more insights.
 
 [di]: https://codefresh.io/docker-tutorial/not-ignore-dockerignore-2/
 [oci]: https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/doc/WHITEPAPER.md
+++ b/doc/WHITEPAPER.md
@@ -1,9 +1,9 @@
 # An approach to reusable build environments
 
-- **Version**: 1.0.1
+- **Version**: 1.0.2
 - **Authors**: Yannick Scherer
 - **Created on**: 03.05.2020
-- **Last updated on**: 24.05.2021
+- **Last updated on**: 09.05.2022
 
 ## Introduction
 

--- a/src/into/build.clj
+++ b/src/into/build.clj
@@ -34,9 +34,7 @@
    [nil "--cache path" "Run an incremental build utilising the given cache file."
     :id :cache-file]
    [nil, "--platform platform" "Set platform for runner container and resulting image."
-    :id :platform]
-   [nil "--force-platform" "Use platform for all containers to ensure compatibility."
-    :id :force-platform?]])
+    :id :platform]])
 
 ;; ## Spec
 
@@ -48,7 +46,6 @@
            ci-type
            incremental?
            platform
-           force-platform?
            no-volumes?]}
    [builder-image source-path]]
   (cond-> {:builder-image-name builder-image
@@ -59,9 +56,7 @@
     artifact-path (assoc :artifact-path artifact-path)
     profile       (assoc :profile profile)
     ci-type       (assoc :ci-type ci-type)
-    platform      (cond->
-                   force-platform? (assoc :builder-platform platform)
-                   :always         (assoc :runner-platform platform))
+    platform      (assoc :platform platform)
     cache-file    (merge {:cache-from cache-file, :cache-to cache-file})))
 
 ;; ## Run

--- a/src/into/build/pull.clj
+++ b/src/into/build/pull.clj
@@ -20,17 +20,17 @@
 
 (defn- pull-builder-image!
   [{:keys [spec] :as data}]
-  (let [{:keys [builder-image-name builder-platform]} spec]
-    (pull-image! data :builder-image builder-platform builder-image-name)))
+  (let [{:keys [builder-image-name]} spec]
+    (pull-image! data :builder-image nil builder-image-name)))
 
 (defn- pull-runner-image!
   [{:keys [spec] :as data}]
-  (let [{:keys [target-image-name runner-platform]} spec]
+  (let [{:keys [target-image-name platform]} spec]
     (if target-image-name
       (->> (get-in data [:builder-image
                          :labels
                          constants/runner-image-label])
-           (pull-image! data :runner-image runner-platform))
+           (pull-image! data :runner-image platform))
       data)))
 
 (defn- set-builder-user

--- a/src/into/build/pull.clj
+++ b/src/into/build/pull.clj
@@ -9,9 +9,12 @@
 
 (defn- pull-image!
   [{:keys [client] :as data} target-key platform image-name]
-  (log/debug "  Pulling image [%s] ..." image-name)
-  (when-let [p (or platform (:platform client))]
-    (log/debug "    Platform: %s" p))
+  (log/debug "  Pulling image [%s]%s ..."
+             image-name
+             (if-let [p (or platform (:platform client))]
+               (format " for platform [%s]" p)
+               ""))
+
   (if-let [image (-> client
                      (cond-> platform (docker/with-platform platform))
                      (docker/pull-image-record image-name))]

--- a/src/into/build/spec.clj
+++ b/src/into/build/spec.clj
@@ -61,8 +61,7 @@
                    ::cache-from
                    ::cache-to
                    ::ci-type
-                   ::builder-platform
-                   ::runner-platform
+                   ::platform
                    ::target-image-name]))
 
 (s/def ::source-path ::path)
@@ -70,8 +69,6 @@
 (s/def ::builder-image-name ::image-name)
 (s/def ::target-image-name ::image-name)
 (s/def ::profile ::name)
-(s/def ::builder-platform string?)
-(s/def ::runner-platform string?)
 (s/def ::ci-type #{"github-actions", "local"})
 (s/def ::use-volumes? boolean?)
 (s/def ::use-cache-volume? boolean?)

--- a/src/into/build/spec.clj
+++ b/src/into/build/spec.clj
@@ -70,6 +70,7 @@
 (s/def ::target-image-name ::image-name)
 (s/def ::profile ::name)
 (s/def ::ci-type #{"github-actions", "local"})
+(s/def ::platform string?)
 (s/def ::use-volumes? boolean?)
 (s/def ::use-cache-volume? boolean?)
 


### PR DESCRIPTION
It's better to use `DOCKER_DEFAULT_PLATFORM` if you want to have the builder use a specific platform.