### PR TITLE
Upgrade GraalVM & Dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,14 @@ jobs:
   configure:
     runs-on: ubuntu-latest
     outputs:
-      graalvm-version: ${{ steps.setup.outputs.graalvm-version }}
+      graalvm-distribution: ${{ steps.setup.outputs.graalvm-distribution }}
       java-version: ${{ steps.setup.outputs.java-version }}
     steps:
-      - name: setup-configuration
+      - name: setup
         id: setup
         run: |
-          echo ::set-output name=graalvm-version::21.2.0
-          echo ::set-output name=java-version::java11
+          echo "graalvm-distribution=graalvm-community" >> "$GITHUB_OUTPUT"
+          echo "java-version=21" >> "$GITHUB_OUTPUT"
 
   uberjar:
     needs: configure
@@ -27,11 +27,12 @@ jobs:
       # We need to compile using the GraalVM JDK, not the default one. This
       # (hopefully) ensures compatibility, as wel as an explicit choice of
       # Java version.
-      - name: setup-graalvm-ce
-        uses: DeLaGuardo/setup-graalvm@4.0
+      #
+      - name: setup-graalvm
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: ${{ needs.configure.outputs.graalvm-version }}
-          java: ${{ needs.configure.outputs.java-version }}
+          distribution: ${{ needs.configure.outputs.graalvm-distribution }}
+          java-version: ${{ needs.configure.outputs.java-version }}
 
       - uses: actions/checkout@v2
       - name: install-dependencies
@@ -86,28 +87,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: setup-graalvm-ce
-        uses: DeLaGuardo/setup-graalvm@4.0
+      - name: setup-graalvm
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: ${{ needs.configure.outputs.graalvm-version }}
-          java: ${{ needs.configure.outputs.java-version }}
+          distribution: ${{ needs.configure.outputs.graalvm-distribution }}
+          java-version: ${{ needs.configure.outputs.java-version }}
 
-      - name: setup-paths
+      - name: setup-tool-paths
         id: paths
         run: |
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            echo ::set-output name=gu::gu.cmd
-            echo ::set-output name=native-image::native-image.cmd
-            echo ::set-output name=artifact::into.exe
+            echo "NATIVE_IMAGE=native-image.cmd" >> "$GITHUB_ENV"
+            echo "ARTIFACT_NAME=into.exe" >> "$GITHUB_ENV"
           else
-            echo ::set-output name=gu::gu
-            echo ::set-output name=native-image::native-image
-            echo ::set-output name=artifact::into
+            echo "NATIVE_IMAGE=native-image" >> "$GITHUB_ENV"
+            echo "ARTIFACT_NAME=into" >> "$GITHUB_ENV"
           fi
         shell: bash
 
-      - name: setup-native-image
-        run: ${{ steps.paths.outputs.gu }} install native-image
       - name: setup-windows-toolchain
         uses: ilammy/msvc-dev-cmd@v1
         if: startsWith(matrix.build, 'windows-')
@@ -117,15 +114,14 @@ jobs:
           name: uberjar
       - name: native-image
         run: |
-          ${{ steps.paths.outputs.native-image }} -jar uberjar/app.jar \
-            -H:Name=into \
+          ${{ env.NATIVE_IMAGE }} -jar uberjar/app.jar \
+            -o into \
             --no-fallback \
-            --no-server \
             ${{ matrix.flags }}
         shell: bash
       - name: verify-native-image
         run: |
-          export ARTIFACT="${{ github.workspace }}/${{ steps.paths.outputs.artifact }}"
+          export ARTIFACT="${{ github.workspace }}/${{ env.ARTIFACT_NAME }}"
           chmod +x "$ARTIFACT"
           "$ARTIFACT" --version
         shell: bash
@@ -133,7 +129,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.build }}
-          path: ${{ steps.paths.outputs.artifact }}
+          path: ${{ env.ARTIFACT_NAME }}
 
   test-native-image:
     needs: [create-native-image]

--- a/project.clj
+++ b/project.clj
@@ -6,41 +6,47 @@
             :year 2020
             :key "mit"
             :comment "MIT License"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.clojure/tools.cli "1.0.206"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/tools.cli "1.0.219"]
                  [org.clojure/tools.logging "1.2.4"]
 
                  ;; components
                  [lispyclouds/clj-docker-client "1.0.3"]
-                 [unixsocket-http "1.0.12"]
-                 [com.squareup.okhttp3/okhttp "4.9.3"]
-                 [com.squareup.okhttp3/okhttp-tls "4.9.3"]
+                 [unixsocket-http "1.0.14"]
+                 [com.squareup.okhttp3/okhttp "4.12.0"]
+                 [com.squareup.okhttp3/okhttp-tls "4.12.0"]
 
                  ;; utilities
-                 [org.apache.commons/commons-compress "1.21"]
+                 [org.apache.commons/commons-compress "1.24.0"]
                  [commons-lang "2.6"]
-                 [potemkin "0.4.5"]
+                 [potemkin "0.4.6"]
 
                  ;; logging
-                 [jansi-clj "1.0.0"]
-                 [ch.qos.logback/logback-classic "1.2.11"]
+                 [jansi-clj "1.0.1"]
+                 [ch.qos.logback/logback-classic "1.4.11"]
+
+                 ;; explicit dependencies for GraalVM compatibility
+                 [com.fasterxml.jackson.core/jackson-core "2.15.3"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.15.3"]
 
                  ;; cleanup dependency chain
                  [riddley "0.2.0"]
-                 [org.jetbrains.kotlin/kotlin-stdlib-common "1.6.10"]]
+                 [org.jetbrains.kotlin/kotlin-stdlib-common "1.9.10"]
+                 [org.jetbrains.kotlin/kotlin-stdlib-jdk8 "1.9.10"]]
   :exclusions [org.clojure/clojure]
   :java-source-paths ["src"]
   :profiles {:dev
              {:dependencies [[org.clojure/test.check "1.1.1"]
-                             [com.gfredericks/test.chuck "0.2.13"]]
+                             [com.gfredericks/test.chuck "0.2.14"]]
               :global-vars {*warn-on-reflection* true}}
              :kaocha
-             {:dependencies [[lambdaisland/kaocha "1.63.998"
+             {:dependencies [[lambdaisland/kaocha "1.87.1366"
                               :exclusions [org.clojure/spec.alpha]]
-                             [lambdaisland/kaocha-cloverage "1.0.75"]
+                             [lambdaisland/kaocha-cloverage "1.1.89"]
                              [org.clojure/java.classpath "1.0.0"]]}
              :uberjar
              {:global-vars {*assert* false}
+              :dependencies [[com.github.clj-easy/graal-build-time "1.0.5"]]
               :jvm-opts ["-Dclojure.compiler.direct-linking=true"
                          "-Dclojure.spec.skip-macros=true"]
               :main into.main

--- a/resources/META-INF/native-image/into-docker/into-docker/native-image.properties
+++ b/resources/META-INF/native-image/into-docker/into-docker/native-image.properties
@@ -1,8 +1,11 @@
-Args = --no-server \
-       --no-fallback \
-       --initialize-at-build-time \
-       --allow-incomplete-classpath \
-       -H:EnableURLProtocols=http,https \
+Args = --no-fallback \
+       --features=clj_easy.graal_build_time.InitClojureClasses \
+       --enable-http \
+       --enable-https \
+       --initialize-at-build-time=ch.qos.logback \
+       --initialize-at-build-time=org.yaml.snakeyaml \
+       --initialize-at-build-time=org.slf4j.LoggerFactory \
+       --initialize-at-build-time=com.fasterxml.jackson \
        -H:+ReportExceptionStackTraces \
        -J-Dclojure.spec.skip-macros=true \
        -J-Dclojure.compiler.direct-linking=true \

--- a/test/into/docker/container_test.clj
+++ b/test/into/docker/container_test.clj
@@ -19,8 +19,8 @@
 
 ;; ## Lifecycle
 
-(def ^:dynamic client)
-(def ^:dynamic container)
+(def ^:dynamic client nil)
+(def ^:dynamic container nil)
 
 (defmacro silently
   [form]


### PR DESCRIPTION
* Upgrade to GraalVM CE (Java 21)
  * Use a different Github Action to initialise.
  * Adapt `native-image` parameters.
  * Use `com.github.clj-easy/graal-build-time` for auto-configuration of build time initialisation.
* Upgrade dependencies.
* Adapt Github Actions workflows to use environment/output files.